### PR TITLE
Fix: Add custom error and not-found pages to resolve build error

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,48 @@
+// src/app/error.tsx
+'use client'; // Error components must be Client Components
+
+import { useEffect } from 'react';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // Log the error to an error reporting service
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div style={{ textAlign: 'center', marginTop: '50px', color: 'white' }}>
+      <h2>Something went wrong!</h2>
+      <p>{error.message}</p>
+      <button
+        onClick={
+          // Attempt to recover by trying to re-render the segment
+          () => reset()
+        }
+        style={{
+          padding: '10px 20px',
+          margin: '20px 0',
+          color: 'white',
+          backgroundColor: '#0070f3',
+          border: 'none',
+          borderRadius: '5px',
+          cursor: 'pointer',
+        }}
+      >
+        Try again
+      </button>
+      <br />
+      <Link href="/" style={{ color: '#0070f3', textDecoration: 'underline' }}>
+        Go back home
+      </Link>
+    </div>
+  );
+}
+
+// Need to import Link
+import Link from 'next/link';

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -53,7 +53,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       className={`${inter.className} bg-iron text-white text-center font-sans text-lg`}
     >
       {/* Google Analytics - this is the correct place for it in App Router layouts */}
-      {enableAnalytics && (
+      {/* {enableAnalytics && (
         <>
           <Script
             src={`https://www.googletagmanager.com/gtag/js?id=${googleAnalyticsId}`}
@@ -68,7 +68,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
             `}
           </Script>
         </>
-      )}
+      )} */}
       {children}
     </body>
   );

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,16 @@
+// src/app/not-found.tsx
+'use client'; // Required for not-found page, even if minimal
+
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div style={{ textAlign: 'center', marginTop: '50px', color: 'white' }}>
+      <h1>404 - Page Not Found</h1>
+      <p>Sorry, the page you are looking for does not exist.</p>
+      <Link href="/" style={{ color: '#0070f3', textDecoration: 'underline' }}>
+        Go back home
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
- Temporarily commented out Google Analytics in root layout.
- Added custom src/app/not-found.tsx.
- Added custom src/app/error.tsx.

These changes are intended to work around a TypeError related to `useContext` occurring during the prerendering of default error/not-found pages in Next.js v14.0.3. By providing minimal custom pages, the build process should be able to complete successfully.